### PR TITLE
tests: don't shadow deb_arch in scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ jobs:
       script: sudo ./tools/travis/run_tests.sh tests/unit
     - if: type != cron
       script: SNAPCRAFT_TEST_MOCK_MACHINE=armv7l sudo ./tools/travis/run_tests.sh tests/unit
+    - if: type != cron
+      script: SNAPCRAFT_TEST_MOCK_MACHINE=aarch64 sudo ./tools/travis/run_tests.sh tests/unit
     - stage: osx-integration-store
       os: osx
       script: SNAPCRAFT_FROM_BREW=1 ./tools/travis/run_tests.sh tests.integration.store.test_store_login_logout use-run

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,49 @@
+snapcraft (2.42) xenial; urgency=medium
+
+  [ Sergio Schvezov ]
+  * elf: patch everything instead of a subset of elf files (#2081)
+  * elf: clear the current runpath before setting the rpath (#2085)
+  * python plugin: properly handle distutils on bionic
+  * ci: add the python integration tests on bionic for travis
+  * many: remove support for remote lxd per project containers (#2089)
+  * schema: allow refresh-mode and stop-mode (#2092)
+  * packaging: include changelog for setup.py's version detection (#2097)
+  * ci: enable OSX testing on travis (#2084)
+  * tests: use a common cache for the integration tests
+  * tests: remove the SharedCache fixture and uses of it
+  * many: allow building in containers with no version in project (#2104)
+  * errors: remove logic for SNAPCRAFT_SEND_ERROR_DATA
+  * errors: implement the always option to sent to sentry
+  * package: make use of snapcraftctl snapcraft features (#2103)
+  * nodejs plugin: lazy load the required tarballs (#2106)
+  * build_providers: new build provider using multipass (#2100)
+  * New upstream release (LP: #1767016)
+
+  [ Kyle Fazzari ]
+  * project_loader: support architectures for CI (#2080)
+  * meta: soften warning about using passthrough (#2091)
+  * storeapi: better handle network errors and retries (#2094)
+  * grammar: support compound on..to statement (#2088)
+
+  [ Christian Dywan ]
+  * python: bring back support for older versions of pip (#2055)
+  * tests: don't use os_release and repo from snapcraft (#2096)
+  * lxd: wait for on-going refreshes to finish (#2098)
+  * ci: setup AppVeyor (#2087)
+  * repo: catch error updating the package cache (#2079)
+
+  [ Rakesh Singh ]
+  * dotnet plugin: add dotnet command to path for step overriding (#1909)
+
+  [ Michael Vogt ]
+  * lifecycle: skip -all-root for base snaps (#2090)
+
+  [ Matias Bordese ]
+  * tests: update metadata store integration test, no previous push 
+    required (#2086)
+
+ -- Sergio Schvezov <sergio.schvezov@ubuntu.com>  Thu, 26 Apr 2018 01:58:29 +0000
+
 snapcraft (2.41) xenial; urgency=medium
 
   [ Sergio Schvezov ]
@@ -54,7 +100,7 @@ snapcraft (2.41) xenial; urgency=medium
   [ Colin Watson ]
   * storeapi: fix formatting of some store errors (#2056)
 
- -- <sergio.schvezov@ubuntu.com>  Sat, 14 Apr 2018 12:13:35 +0000
+ -- Sergio Schvezov <sergio.schvezov@ubuntu.com>  Sat, 14 Apr 2018 12:13:35 +0000
 
 snapcraft (2.40.1) xenial; urgency=medium
 

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -1689,9 +1689,9 @@ class ValidArchitecturesYamlTestCase(YamlBaseTestCase):
     ]
 
     arch_scenarios = [
-        ('amd64', {'deb_arch': 'amd64'}),
-        ('i386', {'deb_arch': 'i386'}),
-        ('armhf', {'deb_arch': 'armhf'}),
+        ('amd64', {'target_arch': 'amd64'}),
+        ('i386', {'target_arch': 'i386'}),
+        ('armhf', {'target_arch': 'armhf'}),
     ]
 
     scenarios = multiply_scenarios(yaml_scenarios, arch_scenarios)
@@ -1713,9 +1713,9 @@ class ValidArchitecturesYamlTestCase(YamlBaseTestCase):
 
         try:
             c = _config.Config(
-                snapcraft.project.Project(target_deb_arch=self.deb_arch))
+                snapcraft.project.Project(target_deb_arch=self.target_arch))
 
-            expected = getattr(self, 'expected_{}'.format(self.deb_arch))
+            expected = getattr(self, 'expected_{}'.format(self.target_arch))
             self.assertThat(c.data['architectures'], Equals(expected))
         except errors.YamlValidationError as e:
             self.fail('Expected YAML to be valid, got an error: {}'.format(e))


### PR DESCRIPTION
YamlBaseTestCase already sets to the real value, effectively
overriding whatever the scenario sets.

Also mock arm64 on Travis - unit tests should pass regardless of
the actual hardware.


This fixes this error when run on arm64:

ERROR: test_architectures (tests.unit.project_loader.test_config.ValidArchitecturesYamlTestCase)
tests.unit.project_loader.test_config.ValidArchitecturesYamlTestCase.test_architectures (build on all,i386)
testtools.testresult.real._StringException: Empty attachments:
  pythonlogging:''

traceback-25: {{{
Traceback (most recent call last):
  File "/tmp/autopkgtest.cV5fWl/build.0O3/snapcraft/tests/unit/project_loader/test_config.py", line 1718, in test_architectures
    expected = getattr(self, 'expected_{}'.format(self.deb_arch))
AttributeError: 'ValidArchitecturesYamlTestCase' object has no attribute 'expected_arm64'
}}}