### PR TITLE
tests: parser tests need the cache

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,49 @@
+snapcraft (2.42) xenial; urgency=medium
+
+  [ Sergio Schvezov ]
+  * elf: patch everything instead of a subset of elf files (#2081)
+  * elf: clear the current runpath before setting the rpath (#2085)
+  * python plugin: properly handle distutils on bionic
+  * ci: add the python integration tests on bionic for travis
+  * many: remove support for remote lxd per project containers (#2089)
+  * schema: allow refresh-mode and stop-mode (#2092)
+  * packaging: include changelog for setup.py's version detection (#2097)
+  * ci: enable OSX testing on travis (#2084)
+  * tests: use a common cache for the integration tests
+  * tests: remove the SharedCache fixture and uses of it
+  * many: allow building in containers with no version in project (#2104)
+  * errors: remove logic for SNAPCRAFT_SEND_ERROR_DATA
+  * errors: implement the always option to sent to sentry
+  * package: make use of snapcraftctl snapcraft features (#2103)
+  * nodejs plugin: lazy load the required tarballs (#2106)
+  * build_providers: new build provider using multipass (#2100)
+  * New upstream release (LP: #1767016)
+
+  [ Kyle Fazzari ]
+  * project_loader: support architectures for CI (#2080)
+  * meta: soften warning about using passthrough (#2091)
+  * storeapi: better handle network errors and retries (#2094)
+  * grammar: support compound on..to statement (#2088)
+
+  [ Christian Dywan ]
+  * python: bring back support for older versions of pip (#2055)
+  * tests: don't use os_release and repo from snapcraft (#2096)
+  * lxd: wait for on-going refreshes to finish (#2098)
+  * ci: setup AppVeyor (#2087)
+  * repo: catch error updating the package cache (#2079)
+
+  [ Rakesh Singh ]
+  * dotnet plugin: add dotnet command to path for step overriding (#1909)
+
+  [ Michael Vogt ]
+  * lifecycle: skip -all-root for base snaps (#2090)
+
+  [ Matias Bordese ]
+  * tests: update metadata store integration test, no previous push 
+    required (#2086)
+
+ -- Sergio Schvezov <sergio.schvezov@ubuntu.com>  Thu, 26 Apr 2018 01:58:29 +0000
+
 snapcraft (2.41) xenial; urgency=medium
 
   [ Sergio Schvezov ]
@@ -54,7 +100,7 @@ snapcraft (2.41) xenial; urgency=medium
   [ Colin Watson ]
   * storeapi: fix formatting of some store errors (#2056)
 
- -- <sergio.schvezov@ubuntu.com>  Sat, 14 Apr 2018 12:13:35 +0000
+ -- Sergio Schvezov <sergio.schvezov@ubuntu.com>  Sat, 14 Apr 2018 12:13:35 +0000
 
 snapcraft (2.40.1) xenial; urgency=medium
 

--- a/tests/integration/general/test_parser.py
+++ b/tests/integration/general/test_parser.py
@@ -20,7 +20,7 @@ import subprocess
 
 
 import testscenarios
-from testtools.matchers import Equals
+from testtools.matchers import FileExists, Not
 
 from tests import (
     fixture_setup,
@@ -48,7 +48,10 @@ class ParserTestCase(integration.TestCase):
                 subprocess.CalledProcessError,
                 self.run_snapcraft_parser, args)
 
-        self.assertThat(os.path.exists(part_file), Equals(expect_output))
+        if expect_output:
+            self.assertThat(part_file, FileExists())
+        else:
+            self.assertThat(part_file, Not(FileExists()))
 
 
 class TestParser(ParserTestCase):
@@ -70,6 +73,8 @@ class TestParserWikis(testscenarios.WithScenarios, ParserTestCase):
         temp_cwd_fixture = fixture_setup.TempCWD()
         self.useFixture(temp_cwd_fixture)
         super().setUp()
+        self.useFixture(fixtures.EnvironmentVariable(
+            'XDG_CACHE_HOME', os.path.join(self.path, '.cache')))
 
     def _read_file(self, filename):
         content = ''


### PR DESCRIPTION
Also use FileExists to get a sensible failure message.

This fixes tests.integration.general.test_parser:

test_parser.TestParserWikis.test_local_wiki (snap/snapcraft.yaml)
fatal: '/home/ubuntu/autopkgtest_tmp/tmpmvrvik_y/repo' does not appear to be a git repository
fatal: Could not read from remote repository.
[...]
subprocess.CalledProcessError: Command '['/usr/bin/snapcraft-parser', '-d', '--index', 'wiki', '--output', '/home/ubuntu/autopkgtest_tmp/tmpoh_k4skd/parts.yaml']' returned non-zero exit status 1
}}}

test_parser.TestParserWikis.test_local_wiki (Missing .snapcraft.yaml file)
Processing origin 'repo'
fatal: '/home/ubuntu/autopkgtest_tmp/tmpmvrvik_y/repo' does not appear to be a git repository
fatal: Could not read from remote repository.
[...]
call_parser
    self.assertThat(os.path.exists(part_file), Equals(expect_output))
  File "/usr/lib/python3/dist-packages/testtools/testcase.py", line 435, in assertThat
    raise mismatch_error
testtools.matchers._impl.MismatchError: True != False
}}}