### PR TITLE
tests: fix arch-specific integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ jobs:
       script: sudo ./tools/travis/run_tests.sh tests/unit
     - if: type != cron
       script: SNAPCRAFT_TEST_MOCK_MACHINE=armv7l sudo ./tools/travis/run_tests.sh tests/unit
+    - if: type != cron
+      script: SNAPCRAFT_TEST_MOCK_MACHINE=aarch64 sudo ./tools/travis/run_tests.sh tests/unit
     - stage: osx-integration-store
       os: osx
       script: SNAPCRAFT_FROM_BREW=1 ./tools/travis/run_tests.sh tests.integration.store.test_store_login_logout use-run

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,49 @@
+snapcraft (2.42) xenial; urgency=medium
+
+  [ Sergio Schvezov ]
+  * elf: patch everything instead of a subset of elf files (#2081)
+  * elf: clear the current runpath before setting the rpath (#2085)
+  * python plugin: properly handle distutils on bionic
+  * ci: add the python integration tests on bionic for travis
+  * many: remove support for remote lxd per project containers (#2089)
+  * schema: allow refresh-mode and stop-mode (#2092)
+  * packaging: include changelog for setup.py's version detection (#2097)
+  * ci: enable OSX testing on travis (#2084)
+  * tests: use a common cache for the integration tests
+  * tests: remove the SharedCache fixture and uses of it
+  * many: allow building in containers with no version in project (#2104)
+  * errors: remove logic for SNAPCRAFT_SEND_ERROR_DATA
+  * errors: implement the always option to sent to sentry
+  * package: make use of snapcraftctl snapcraft features (#2103)
+  * nodejs plugin: lazy load the required tarballs (#2106)
+  * build_providers: new build provider using multipass (#2100)
+  * New upstream release (LP: #1767016)
+
+  [ Kyle Fazzari ]
+  * project_loader: support architectures for CI (#2080)
+  * meta: soften warning about using passthrough (#2091)
+  * storeapi: better handle network errors and retries (#2094)
+  * grammar: support compound on..to statement (#2088)
+
+  [ Christian Dywan ]
+  * python: bring back support for older versions of pip (#2055)
+  * tests: don't use os_release and repo from snapcraft (#2096)
+  * lxd: wait for on-going refreshes to finish (#2098)
+  * ci: setup AppVeyor (#2087)
+  * repo: catch error updating the package cache (#2079)
+
+  [ Rakesh Singh ]
+  * dotnet plugin: add dotnet command to path for step overriding (#1909)
+
+  [ Michael Vogt ]
+  * lifecycle: skip -all-root for base snaps (#2090)
+
+  [ Matias Bordese ]
+  * tests: update metadata store integration test, no previous push 
+    required (#2086)
+
+ -- Sergio Schvezov <sergio.schvezov@ubuntu.com>  Thu, 26 Apr 2018 01:58:29 +0000
+
 snapcraft (2.41) xenial; urgency=medium
 
   [ Sergio Schvezov ]
@@ -54,7 +100,7 @@ snapcraft (2.41) xenial; urgency=medium
   [ Colin Watson ]
   * storeapi: fix formatting of some store errors (#2056)
 
- -- <sergio.schvezov@ubuntu.com>  Sat, 14 Apr 2018 12:13:35 +0000
+ -- Sergio Schvezov <sergio.schvezov@ubuntu.com>  Sat, 14 Apr 2018 12:13:35 +0000
 
 snapcraft (2.40.1) xenial; urgency=medium
 

--- a/tests/integration/general/test_parser.py
+++ b/tests/integration/general/test_parser.py
@@ -20,7 +20,7 @@ import subprocess
 
 
 import testscenarios
-from testtools.matchers import Equals
+from testtools.matchers import FileExists, Not
 
 from tests import (
     fixture_setup,
@@ -48,7 +48,10 @@ class ParserTestCase(integration.TestCase):
                 subprocess.CalledProcessError,
                 self.run_snapcraft_parser, args)
 
-        self.assertThat(os.path.exists(part_file), Equals(expect_output))
+        if expect_output:
+            self.assertThat(part_file, FileExists())
+        else:
+            self.assertThat(part_file, Not(FileExists()))
 
 
 class TestParser(ParserTestCase):
@@ -70,6 +73,8 @@ class TestParserWikis(testscenarios.WithScenarios, ParserTestCase):
         temp_cwd_fixture = fixture_setup.TempCWD()
         self.useFixture(temp_cwd_fixture)
         super().setUp()
+        self.useFixture(fixtures.EnvironmentVariable(
+            'XDG_CACHE_HOME', os.path.join(self.path, '.cache')))
 
     def _read_file(self, filename):
         content = ''

--- a/tests/integration/general/test_version_script.py
+++ b/tests/integration/general/test_version_script.py
@@ -81,7 +81,8 @@ class VersionScriptTestCase(testscenarios.WithScenarios,
         self.run_snapcraft('snap')
 
         self.assertThat(
-            'version-script-test_{}_amd64.snap'.format(self.expected_version),
+            'version-script-test_{}_{}.snap'.format(
+                self.expected_version, self.deb_arch),
             FileExists())
 
 

--- a/tests/integration/sources/test_git_source.py
+++ b/tests/integration/sources/test_git_source.py
@@ -126,7 +126,6 @@ class GitGenerateVersionTestCase(integration.GitSourceBaseTestCase):
                 version: git
                 summary: test git generated version
                 description: test git generated version with git hint
-                architectures: [amd64]
                 parts:
                     nil:
                         plugin: nil
@@ -138,7 +137,8 @@ class GitGenerateVersionTestCase(integration.GitSourceBaseTestCase):
     def test_tag(self):
         self.tag('2.0')
         self.run_snapcraft('snap')
-        self.assertThat('git-test_2.0_amd64.snap', FileExists())
+        self.assertThat(
+            'git-test_2.0_{}.snap'.format(self.deb_arch), FileExists())
 
     def test_tag_with_commits_ahead(self):
         self.tag('2.0')
@@ -147,13 +147,15 @@ class GitGenerateVersionTestCase(integration.GitSourceBaseTestCase):
         self.commit('new stub file')
         self.run_snapcraft('snap')
         revno = self.get_revno()[:7]
-        expected_file = 'git-test_2.0+git1.{}_amd64.snap'.format(revno)
+        expected_file = 'git-test_2.0+git1.{}_{}.snap'.format(
+            revno, self.deb_arch)
         self.assertThat(expected_file, FileExists())
 
     def test_no_tag(self):
         self.run_snapcraft('snap')
         revno = self.get_revno()[:7]
-        expected_file = 'git-test_0+git.{}_amd64.snap'.format(revno)
+        expected_file = 'git-test_0+git.{}_{}.snap'.format(
+            revno, self.deb_arch)
         self.assertThat(expected_file, FileExists())
 
     def test_no_git(self):

--- a/tests/unit/project_loader/grammar_processing/test_part_grammar_processor.py
+++ b/tests/unit/project_loader/grammar_processing/test_part_grammar_processor.py
@@ -26,6 +26,7 @@ from snapcraft.internal.project_loader.grammar_processing import (
     _part_grammar_processor as processor
 )
 from tests import unit
+from tests.fixture_setup import FakeSnapd
 
 
 def load_tests(loader, tests, ignore):
@@ -225,6 +226,15 @@ class PartGrammarBuildSnapsTestCase(unit.TestCase):
     ]
 
     scenarios = multiply_scenarios(source_scenarios, arch_scenarios)
+
+    def setUp(self):
+        super().setUp()
+
+        fake_snapd = FakeSnapd()
+        fake_snapd.find_result = [{
+            'hello': {'channels': {
+                'latest/stable': {'confinement': 'devmode'}}}}]
+        self.useFixture(fake_snapd)
 
     @mock.patch('platform.architecture')
     @mock.patch('platform.machine')

--- a/tests/unit/project_loader/test_config.py
+++ b/tests/unit/project_loader/test_config.py
@@ -1689,9 +1689,9 @@ class ValidArchitecturesYamlTestCase(YamlBaseTestCase):
     ]
 
     arch_scenarios = [
-        ('amd64', {'deb_arch': 'amd64'}),
-        ('i386', {'deb_arch': 'i386'}),
-        ('armhf', {'deb_arch': 'armhf'}),
+        ('amd64', {'target_arch': 'amd64'}),
+        ('i386', {'target_arch': 'i386'}),
+        ('armhf', {'target_arch': 'armhf'}),
     ]
 
     scenarios = multiply_scenarios(yaml_scenarios, arch_scenarios)
@@ -1713,9 +1713,9 @@ class ValidArchitecturesYamlTestCase(YamlBaseTestCase):
 
         try:
             c = _config.Config(
-                snapcraft.project.Project(target_deb_arch=self.deb_arch))
+                snapcraft.project.Project(target_deb_arch=self.target_arch))
 
-            expected = getattr(self, 'expected_{}'.format(self.deb_arch))
+            expected = getattr(self, 'expected_{}'.format(self.target_arch))
             self.assertThat(c.data['architectures'], Equals(expected))
         except errors.YamlValidationError as e:
             self.fail('Expected YAML to be valid, got an error: {}'.format(e))


### PR DESCRIPTION
test_git_source.py was bitten by the breakage introduced by the new
`architectures` field syntax. Rewrite them to be
non-architecture-specific.

Signed-off-by: Kyle Fazzari <kyrofa@ubuntu.com>